### PR TITLE
fix: Update NumPy to 2.2.6 to resolve MT19937 BitGenerator compatibility

### DIFF
--- a/requirements-prediction.txt
+++ b/requirements-prediction.txt
@@ -6,9 +6,9 @@ python-multipart==0.0.20
 python-dotenv==1.0.1
 requests==2.31.0
 
-# Essential data handling
+# Essential data handling - UPDATED for model compatibility
 pandas==2.2.2
-numpy==1.26.4
+numpy==2.2.6
 
 # ML libraries for predictions - UPDATED for model compatibility
 scikit-learn==1.7.0


### PR DESCRIPTION
CRITICAL FIX for 'MT19937 is not a known BitGenerator module' error:

The models were trained with NumPy 2.2.6 but Docker was using NumPy 1.26.4, causing incompatibility with the random number generator states in pickled models.

Changes:
- Updated numpy from 1.26.4 to 2.2.6 to match training environment
- Resolves ValueError with numpy.random._mt19937.MT19937 module
- Ensures all 24 ML models can load their random states correctly

This fixes the final compatibility issue preventing model loading in production. Models should now initialize successfully and health checks should pass.