### PR TITLE
Remove Compare tab from navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,6 @@ import Dashboard from './components/Dashboard';
 import DataVisualization from './components/DataVisualization';
 import ExtractionStatus from './components/ExtractionStatus';
 import VideoPerformancePredictor from './components/VideoPerformancePredictor';
-import ComparisonAnalytics from './components/ComparisonAnalytics';
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
@@ -131,13 +130,6 @@ function App() {
                 loading={loading}
                 darkMode={darkMode}
                 onRefresh={loadData}
-              />
-            } />
-            <Route path="/comparison" element={
-              <ComparisonAnalytics 
-                data={extractionData} 
-                loading={loading}
-                darkMode={darkMode}
               />
             } />
           </Routes>

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { BarChart3, Database, Activity, RefreshCw, Moon, Sun, Youtube, Brain, TrendingUp } from 'lucide-react';
+import { BarChart3, Database, Activity, RefreshCw, Moon, Sun, Youtube, Brain } from 'lucide-react';
 
 const Navigation = ({ darkMode, setDarkMode, onRefresh }) => {
   const location = useLocation();
@@ -8,7 +8,6 @@ const Navigation = ({ darkMode, setDarkMode, onRefresh }) => {
   const navItems = [
     { path: '/', icon: BarChart3, label: 'Dashboard' },
     { path: '/visualization', icon: Database, label: 'Data Viz' },
-    { path: '/comparison', icon: TrendingUp, label: 'Compare' },
     { path: '/predictor', icon: Brain, label: 'AI Predictor' },
     { path: '/status', icon: Activity, label: 'Status' },
   ];


### PR DESCRIPTION
- Remove redundant Compare tab since comparison functionality already exists
- Users can compare by adjusting inputs in AI Predictor (titles, thumbnails, genres)
- Data Viz already provides channel/performance comparisons
- Simplifies UI and focuses on core prediction functionality
- Removes ComparisonAnalytics route and unused TrendingUp import

UI improvements:
- Cleaner navigation with 4 focused tabs
- Better UX through iterative testing vs complex comparison interfaces
- Maintains existing comparison capabilities in current workflow