### PR TITLE
Fix: Add confidence levels display to prediction results

### DIFF
--- a/src/prediction_api.py
+++ b/src/prediction_api.py
@@ -691,6 +691,11 @@ class YouTubePredictionSystem:
                 'sharpness': thumbnail_features.get('sharpness', 0)
             },
             'confidence_score': 0.85 if thumbnail_data and self.tfidf else 0.65,
+            'confidence': {
+                'views': 'High' if thumbnail_data and self.tfidf else 'Medium',
+                'rqs': 'High' if thumbnail_data and self.tfidf else 'Medium', 
+                'ctr': 'High' if thumbnail_data and self.tfidf else 'Medium'
+            },
             'model_version': '3.1',
             'guardrails_applied': bool(self.guardrails),
             'embeddings_available': bool(self.tfidf)


### PR DESCRIPTION
- Add confidence object with views/rqs/ctr confidence levels to API response
- Frontend expects confidence.views, confidence.rqs, confidence.ctr fields
- Returns 'High' confidence when thumbnail + embeddings available, 'Medium' otherwise
- Confidence levels now display properly in prediction cards with color coding
- Maintains existing confidence_score field for backwards compatibility

UI improvements:
- Green text for 'High' confidence
- Yellow text for 'Medium' confidence
- Red text for 'Low' confidence (future use)
- Better user feedback on prediction reliability