### PR TITLE
Fix: Revert to npm install due to missing package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # Copy frontend package files
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
-RUN npm ci --only=production
+RUN npm install --only=production
 
 # Copy frontend source and build
 COPY frontend/ .


### PR DESCRIPTION
- npm ci requires package-lock.json which doesn't exist in project
- Fall back to npm install --only=production for now
- Still optimized: excludes dev dependencies for smaller image
- TODO: Generate package-lock.json for future npm ci usage